### PR TITLE
HeaderLogoのスタイルが切り替わる幅を '$tiny' から '$small' に変更

### DIFF
--- a/brigade/nagasaki/components/SideNavigation.vue
+++ b/brigade/nagasaki/components/SideNavigation.vue
@@ -316,7 +316,7 @@ export default Vue.extend({
 }
 
 .SideNavigation-HeaderLogo {
-  @include lessThan($tiny) {
+  @include lessThan($small) {
     width: 100px;
   }
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

東京版とロゴ画像のサイズが違うため、レイアウトが崩れるみたいです。
画像サイズを変えて対応する方法もありますが、CSSで修正しました。
問題ないかご確認お願いします。

## 👏 解決する issue / Resolved Issues
- close #124 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- HeaderLogoのスタイルが切り替わる幅を '$tiny' から '$small' に変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

|before|after|
|-|-|
|<img width="269" alt="スクリーンショット 2020-04-08 22 56 07" src="https://user-images.githubusercontent.com/1921209/78794035-2baa9b80-79ee-11ea-98ed-72e0803ab112.png">|<img width="272" alt="スクリーンショット 2020-04-08 22 57 35" src="https://user-images.githubusercontent.com/1921209/78794068-3402d680-79ee-11ea-9845-0abe77da51f9.png">|