### PR TITLE
陽性患者の属性カード下部の表示くずれを修正　[object][object] → 更新日

### DIFF
--- a/brigade/nagasaki/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/brigade/nagasaki/components/cards/ConfirmedCasesAttributesCard.vue
@@ -5,7 +5,7 @@
       :title-id="'attributes-of-confirmed-cases'"
       :chart-data="data.patientsTable"
       :chart-option="{}"
-      :date="data.attributes"
+      :date="data.releaseDate"
       :info="data.sumInfoOfPatients"
       :url="
         'https://data.bodik.jp/dataset/420000_covidpatients/resource/de7ce61e-1849-47a1-b758-bca3f809cdf8'
@@ -67,7 +67,8 @@ export default {
       const data = {
         attributes,
         patientsTable,
-        sumInfoOfPatients
+        sumInfoOfPatients,
+        releaseDate
       }
       return data
     }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

陽性患者の属性カード下部の表示くずれを修正
正常に表示されている状態になりました。

## 👏 解決する issue / Resolved Issues
- close #134 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- dataへ日付のLastUpDataを出力するよう調整

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

|before|after|
|-|-|
|<img width="610" alt="スクリーンショット 2020-04-09 19 45 11" src="https://user-images.githubusercontent.com/62322626/78887580-1770a800-7a9b-11ea-8d54-9dd2fb4344ba.png">|<img width="589" alt="スクリーンショット 2020-04-09 21 01 31" src="https://user-images.githubusercontent.com/62322626/78893082-9965ce80-7aa5-11ea-912f-630137fd64a3.png">|

