### PR TITLE
OGP画像がシェアデバッガーを通しても更新さるように幅と高さを指定 #191

### DIFF
--- a/assets/locales/nagasaki/en.json
+++ b/assets/locales/nagasaki/en.json
@@ -267,7 +267,9 @@
   "※最新の情報はWebページをご覧ください": "* Please check the latest information from the web site.",
   "〇": "✔",
   "ogp": {
-    "og:image": "https://nagasaki.stopcovid19.jp/ogp.png"
+    "og:image": "https://nagasaki.stopcovid19.jp/ogp.png",
+    "og:width": "1200",
+    "og:height": "630"
   },
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/us/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=en",

--- a/assets/locales/nagasaki/ja.json
+++ b/assets/locales/nagasaki/ja.json
@@ -265,7 +265,9 @@
   "※最新の情報はWebページをご覧ください": "※最新の情報はWebページをご覧ください",
   "〇": "〇",
   "ogp": {
-    "og:image": "https://nagasaki.stopcovid19.jp/ogp.png"
+    "og:image": "https://nagasaki.stopcovid19.jp/ogp.png",
+    "og:width": "1200",
+    "og:height": "630"
   },
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/jp/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=ja",

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -182,6 +182,16 @@ export default Vue.extend({
           hid: 'twitter:image',
           name: 'twitter:image',
           content: this.$tc('ogp.og:image')
+        },
+        {
+          hid: 'og:image:width',
+          name: 'og:image:width',
+          content: this.$tc('ogp.og:width')
+        },
+        {
+          hid: 'og:image:height',
+          name: 'og:image:height',
+          content: this.$tc('ogp.og:height')
         }
       ]
     }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->
OGP画像がシェアデバッガーを通しても更新さるように幅と高さを指定

## 📝 関連する issue / Related Issues
- #191

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

高さと幅を指定したら更新されるという情報を元にページヘッダーに

以下が追加されるようにしました

```
<meta property="og:image:width" content="1200" /> 
<meta property="og:image:height" content="630" />
```

https://qiita.com/niusounds/items/7d7d779e0fc3787e2be3

<img width="589" alt="スクリーンショット 2020-04-14 20 04 00" src="https://user-images.githubusercontent.com/1316886/79218294-25ec0480-7e8b-11ea-9b7a-dfb59d0e60a7.png">

## special thanks 

@tkt989



