### PR TITLE
#209 bodik1が空の時にダミーデータを表示するようにして、エラー表示を回避するようにした。

### DIFF
--- a/brigade/nagasaki/components/cards/TestedNumberCard.vue
+++ b/brigade/nagasaki/components/cards/TestedNumberCard.vue
@@ -28,14 +28,15 @@ export default {
     },
 
     inspectionsGraph() {
+      const dumy = [{ 日付: '2020/3/1', 小計: 0 }]
       const bodik = this.$store.state.bodik1
+      if (!bodik || bodik.length === 0) return formatGraph(dumy)
 
       // 検査実施日別状況
       const graph = bodik.map(item => {
-        return { 日付: item.年月日, 小計: Number(item.件数) }
+        return { 日付: item.年月日, 小計: item.件数 ? Number(item.件数) : 0 }
       })
-      const inspectionsGraph = formatGraph(graph)
-      return inspectionsGraph
+      return formatGraph(graph)
     }
   }
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->
bodik1が空の時にダミーデータを表示するようにして、エラー表示を回避するようにした。
## 📝 関連する issue / Related Issues
- #209

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- bodik1が空の時にダミーデータを表示するようにした。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="1365" alt="スクリーンショット 2020-04-17 23 36 00" src="https://user-images.githubusercontent.com/1316886/79580605-365ae400-8104-11ea-935a-2a21c0ad165a.png">
