### PR TITLE
検査実施件数グラフを県内、県内以外（クルーズ船）と分けて表示

### DIFF
--- a/services/bodikApi.js
+++ b/services/bodikApi.js
@@ -4,7 +4,7 @@ const API_ROOT = 'https://data.bodik.jp/api/action/'
 const actionDatastoreSearch = 'datastore_search?resource_id='
 const baseUrl = API_ROOT + actionDatastoreSearch
 
-const nagasakiPrefectureTestedCasesId = '71e83845-2648-4cb3-a69d-9f5f5412feb2'
+const nagasakiPrefectureTestedCasesId = '660c1ea1-3ed6-44de-9a2e-407508cb23c2'
 const nagasakiPrefectureConfirmedCasesId =
   'de7ce61e-1849-47a1-b758-bca3f809cdf8'
 const nagasakiCityNewsId = 'eb0ba50a-7a97-4029-9b75-9c6bab0568f6'


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #243 


## ⛏ 変更内容 / Details of Changes
- 検査実施件数グラフを県内、県内以外（クルーズ船）と分けて表示
- ⚠陽性患者数の表示がおかしくなっている

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/4303909/79993351-9fb96900-84ef-11ea-89c0-2a95a844862d.png)

![image](https://user-images.githubusercontent.com/4303909/79993369-a516b380-84ef-11ea-9dd3-572a3cca3fb5.png)
